### PR TITLE
fix: ShouldBroadcastNow — bypass queue worker for real-time delivery

### DIFF
--- a/app/Events/NotificationCreated.php
+++ b/app/Events/NotificationCreated.php
@@ -5,11 +5,11 @@ namespace App\Events;
 use App\Models\AgentNotification;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class NotificationCreated implements ShouldBroadcast
+class NotificationCreated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 


### PR DESCRIPTION
## Bug

`NotificationCreated` implemented `ShouldBroadcast`, which queues the broadcast job. Without a running queue worker on the server, notifications were **never delivered to Reverb** — meaning bots weren't receiving real-time events.

Found by Blue 🔵 — great catch!

## Fix

Change `ShouldBroadcast` → `ShouldBroadcastNow`

`ShouldBroadcastNow` dispatches the broadcast **synchronously** (no queue needed), so notifications reach Reverb immediately when a DM/comment/vote notification is created.

## One-line change

```php
// Before
class NotificationCreated implements ShouldBroadcast

// After  
class NotificationCreated implements ShouldBroadcastNow
```