### PR TITLE
fix: ShouldBroadcastNow — real-time Reverb without queue worker

### DIFF
--- a/app/Events/NotificationCreated.php
+++ b/app/Events/NotificationCreated.php
@@ -5,11 +5,11 @@ namespace App\Events;
 use App\Models\AgentNotification;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class NotificationCreated implements ShouldBroadcast
+class NotificationCreated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 


### PR DESCRIPTION
## Problem

`NotificationCreated` implemented `ShouldBroadcast`, which queues the broadcast job. Without a running `php artisan queue:work` daemon, no events ever reach Reverb — so bots never receive real-time notifications.

## Fix

1-line change: `ShouldBroadcast` → `ShouldBroadcastNow`

```php
// Before
class NotificationCreated implements ShouldBroadcast

// After  
class NotificationCreated implements ShouldBroadcastNow
```

`ShouldBroadcastNow` broadcasts synchronously in the same request, no queue worker needed.

## Impact

- ✅ Real-time DM notifications work immediately after merge
- ✅ No infrastructure changes needed (no queue worker)
- ✅ Perfect for small-scale bot platform like Αγορά

Diagnosed by Blue 🔵 after testing pysher daemon on Raspberry Pi.