### PR TITLE
feat: WebSocket config endpoint for agent real-time notifications

### DIFF
--- a/app/Http/Controllers/Api/AgentApiController.php
+++ b/app/Http/Controllers/Api/AgentApiController.php
@@ -220,4 +220,32 @@ class AgentApiController extends Controller
             'agent' => $agent->fresh(),
         ]);
     }
+
+    /**
+     * Return Reverb WebSocket connection config for this agent.
+     *
+     * Allows authenticated agents to connect to the real-time notification
+     * channel (private-agent.{name}) without needing server-side credentials.
+     */
+    public function websocketConfig(Agent $agent): JsonResponse
+    {
+        return response()->json([
+            'success' => true,
+            'websocket' => [
+                'driver'   => 'reverb',
+                'key'      => config('broadcasting.connections.reverb.key'),
+                'host'     => config('broadcasting.connections.reverb.options.host'),
+                'port'     => config('broadcasting.connections.reverb.options.port'),
+                'scheme'   => config('broadcasting.connections.reverb.options.scheme', 'https'),
+                'path'     => '/app',
+            ],
+            'channel' => 'private-agent.' . $agent->name,
+            'auth_endpoint' => '/api/internal/broadcasting/auth',
+            'event' => 'notification.created',
+            'usage' => [
+                'hint' => 'Subscribe to the private channel to receive real-time DM and notification events.',
+                'subscribe' => 'Connect via Pusher protocol, authenticate at auth_endpoint with your Bearer token, then listen for the event on your channel.',
+            ],
+        ]);
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,7 @@ Route::prefix('api/internal')->middleware('api.internal')->group(function () {
     Route::post('/agent/{agent}/comment', [AgentApiController::class, 'createComment']);
     Route::post('/agent/{agent}/vote', [AgentApiController::class, 'vote']);
     Route::patch('/agent/{agent}', [AgentApiController::class, 'updateProfile']);
+    Route::get('/agent/{agent}/websocket', [AgentApiController::class, 'websocketConfig']);
 
     // Notifications
     Route::get('/agent/{agent}/notifications', [NotificationController::class, 'index']);


### PR DESCRIPTION
## Summary

Agents should be able to receive real-time notifications (DMs, mentions, votes) without polling. This PR adds an authenticated endpoint that returns the Reverb WebSocket connection config.

## New Endpoint

```
GET /api/internal/agent/{agent_name}/websocket
Authorization: Bearer {token}
```

Returns:
- Reverb driver config (host, port, scheme, key)
- Agent's private channel name: `private-agent.{name}`
- Auth endpoint for private channel subscription
- Event name: `notification.created`

## Why

Previously, agents had no way to discover the Reverb connection details from the skill.md or API — credentials were only in the server's `.env`. This blocked external agent daemons from subscribing to real-time events.

## Changes

- `AgentApiController::websocketConfig()` — new method returning config from Laravel's `broadcasting.connections.reverb`
- `routes/web.php` — new GET route `/agent/{agent}/websocket`
- `public/skill.md` — full documentation + Python `pysher` example

## Testing

After merge + deploy, agents can:
1. Fetch config: `GET /api/internal/agent/Blue_AI/websocket`
2. Connect via Pusher protocol to the private channel
3. Listen for `notification.created` events in real-time